### PR TITLE
🐛 Fix double slashes in breadcrumb JSON-LD URLs

### DIFF
--- a/src/lib/seo/breadcrumb-schema.ts
+++ b/src/lib/seo/breadcrumb-schema.ts
@@ -28,7 +28,9 @@ export interface BreadcrumbConfig {
  * Generates BreadcrumbList JSON-LD schema for different page types
  */
 export function generateBreadcrumbSchema(config: BreadcrumbConfig): BreadcrumbListSchema {
-  const { locale, baseUrl, category, ocasion, productTitle, productId, sortBy } = config;
+  const { locale, category, ocasion, productTitle, productId, sortBy } = config;
+  // Normalize baseUrl by removing trailing slashes to prevent double slashes in URLs
+  const baseUrl = config.baseUrl.replace(/\/+$/, '');
 
   const breadcrumbItems: BreadcrumbItem[] = [];
   let position = 1;
@@ -135,6 +137,8 @@ function getLocalizedText(key: string, locale: string): string {
  * Generate breadcrumb schema for homepage
  */
 export function generateHomeBreadcrumbSchema(baseUrl: string, locale: string): BreadcrumbListSchema {
+  // Normalize baseUrl by removing trailing slashes
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
   return {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
@@ -143,7 +147,7 @@ export function generateHomeBreadcrumbSchema(baseUrl: string, locale: string): B
         "@type": "ListItem",
         position: 1,
         name: getLocalizedText("home", locale),
-        item: `${baseUrl}/${locale}`
+        item: `${normalizedBaseUrl}/${locale}`
       }
     ]
   };


### PR DESCRIPTION
## 📝 TLDR
Fixes double slashes (`//`) appearing in breadcrumb JSON-LD URLs in production by normalizing the base URL.

## 🔍 Problem
- Breadcrumb URLs were generated with double slashes: `https://cado.md//ro`
- Caused by `BASE_URL` environment variable having a trailing slash in production
- Invalid URLs in structured data could negatively impact SEO

## ✅ Solution
- Normalize `baseUrl` by removing trailing slashes before URL concatenation
- Added `.replace(/\/+$/, '')` to strip any trailing slashes
- Applied fix to both `generateBreadcrumbSchema` and `generateHomeBreadcrumbSchema` functions

## 📊 Changes
- **Before**: `https://cado.md//ro/catalog`
- **After**: `https://cado.md/ro/catalog`

## 🧪 Testing
- ✅ Build passes successfully
- ✅ TypeScript compilation successful
- ✅ URLs properly formatted regardless of BASE_URL configuration

## 🚀 Impact
- Ensures valid Schema.org BreadcrumbList structured data
- Improves SEO with properly formatted URLs
- Defensive coding handles any BASE_URL configuration