### PR TITLE
test: add validation tests for product schemas (Part 1/2)

### DIFF
--- a/src/lib/__tests__/validation/product/product-filters.test.ts
+++ b/src/lib/__tests__/validation/product/product-filters.test.ts
@@ -1,0 +1,577 @@
+import { describe, it, expect } from 'vitest';
+import { getAllProductsRequestSchema } from '@/lib/validation/product/getAllProductsRequest';
+import { getProductRequestSchema } from '@/lib/validation/product/getProductsByFilter';
+import { getAdminProductsRequestSchema } from '@/lib/validation/product/getAdminProducts';
+import { searchTagsRequestSchema } from '@/lib/validation/product/searchTagsRequest';
+import { getRecProductsRequestSchema } from '@/lib/validation/product/getRecProductsRequest';
+import { Categories } from '@/lib/enums/Categories';
+import { Ocasions } from '@/lib/enums/Ocasions';
+import { ProductContent } from '@/lib/enums/ProductContent';
+import SortBy from '@/lib/enums/SortBy';
+import { expectValidData, expectInvalidData } from '../shared/test-helpers';
+
+/**
+ * Product Filter Schema Tests
+ *
+ * Tests for product filtering and search validation schemas:
+ * - getAllProductsRequestSchema: Complex filtering with pagination
+ * - getProductRequestSchema: Filter by ocasion, categories, content
+ * - getAdminProductsRequestSchema: Admin product listing
+ * - searchTagsRequestSchema: Search product tags
+ * - getRecProductsRequestSchema: Get recommended products
+ */
+
+describe('getAllProductsRequestSchema - Complete Product Filtering', () => {
+  describe('Valid Input - Default Values', () => {
+    it('should accept minimal data with defaults', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should apply default limit of 10', () => {
+      const result = getAllProductsRequestSchema.parse({
+        title: null,
+        category: null,
+        price: null,
+      });
+      expect(result.limit).toBe(10);
+    });
+
+    it('should apply default sortBy RECOMMENDED', () => {
+      const result = getAllProductsRequestSchema.parse({
+        title: null,
+        category: null,
+        price: null,
+      });
+      expect(result.sortBy).toBe(SortBy.RECOMMENDED);
+    });
+  });
+
+  describe('Valid Input - Title Search', () => {
+    it('should accept valid title search', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: 'Gift',
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should accept null title', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should accept title with 2 characters', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: 'ab',
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should accept long title search', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: 'a'.repeat(100),
+        category: null,
+        price: null,
+      });
+    });
+  });
+
+  describe('Valid Input - Pagination', () => {
+    it('should accept custom limit', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        limit: 20,
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should accept cursor for pagination', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        cursor: 10,
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should accept null cursor', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        cursor: null,
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should accept undefined cursor', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        cursor: undefined,
+        category: null,
+        price: null,
+      });
+    });
+  });
+
+  describe('Valid Input - Category Filter', () => {
+    it('should accept single category', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: Categories.GIFT_SET,
+        price: null,
+      });
+    });
+
+    it('should accept null category', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+      });
+    });
+
+    Object.values(Categories).forEach(category => {
+      it(`should accept category: ${category}`, () => {
+        expectValidData(getAllProductsRequestSchema, {
+          title: null,
+          category,
+          price: null,
+        });
+      });
+    });
+  });
+
+  describe('Valid Input - Ocasions Filter', () => {
+    it('should accept empty ocasions array', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+        ocasions: [],
+      });
+    });
+
+    it('should accept single ocasion', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+        ocasions: [Ocasions.VALENTINES_DAY],
+      });
+    });
+
+    it('should accept multiple ocasions', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+        ocasions: [Ocasions.VALENTINES_DAY, Ocasions.CHRISTMAS_NEW_YEAR, Ocasions.EASTER],
+      });
+    });
+
+    it('should accept undefined ocasions', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+        ocasions: undefined,
+      });
+    });
+  });
+
+  describe('Valid Input - Product Content Filter', () => {
+    it('should accept empty product content array', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+        productContent: [],
+      });
+    });
+
+    it('should accept single product content', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+        productContent: [ProductContent.COFFEE_TEA],
+      });
+    });
+
+    it('should accept multiple product content types', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+        productContent: [
+          ProductContent.COFFEE_TEA,
+          ProductContent.CHOCOLATE_BISCUITS_CANDY,
+          ProductContent.NUTS_DRY_FRUITS_SPICES,
+        ],
+      });
+    });
+  });
+
+  describe('Valid Input - Price Range', () => {
+    it('should accept price range', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: { min: 10, max: 100 },
+      });
+    });
+
+    it('should accept zero min price', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: { min: 0, max: 100 },
+      });
+    });
+
+    it('should accept same min and max', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: { min: 50, max: 50 },
+      });
+    });
+
+    it('should accept null price', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should accept undefined price', () => {
+      expectValidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: undefined,
+      });
+    });
+  });
+
+  describe('Valid Input - Sort By', () => {
+    Object.values(SortBy).forEach(sortOption => {
+      it(`should accept sortBy: ${sortOption}`, () => {
+        expectValidData(getAllProductsRequestSchema, {
+          title: null,
+          category: null,
+          price: null,
+          sortBy: sortOption,
+        });
+      });
+    });
+  });
+
+  describe('Invalid Input - Title', () => {
+    it('should reject title with 1 character', () => {
+      expectInvalidData(getAllProductsRequestSchema, {
+        title: 'a',
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should reject empty title string', () => {
+      expectInvalidData(getAllProductsRequestSchema, {
+        title: '',
+        category: null,
+        price: null,
+      });
+    });
+  });
+
+  describe('Invalid Input - Limit', () => {
+    it('should reject limit of 0', () => {
+      expectInvalidData(getAllProductsRequestSchema, {
+        title: null,
+        limit: 0,
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should reject limit above 100', () => {
+      expectInvalidData(getAllProductsRequestSchema, {
+        title: null,
+        limit: 101,
+        category: null,
+        price: null,
+      });
+    });
+
+    it('should reject negative limit', () => {
+      expectInvalidData(getAllProductsRequestSchema, {
+        title: null,
+        limit: -1,
+        category: null,
+        price: null,
+      });
+    });
+  });
+
+  describe('Invalid Input - Price', () => {
+    it('should reject negative min price', () => {
+      expectInvalidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: { min: -10, max: 100 },
+      });
+    });
+
+    it('should reject negative max price', () => {
+      expectInvalidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: { min: 0, max: -100 },
+      });
+    });
+  });
+
+  describe('Invalid Input - Invalid Enums', () => {
+    it('should reject invalid category', () => {
+      expectInvalidData(getAllProductsRequestSchema, {
+        title: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        category: 'INVALID_CATEGORY' as any,
+        price: null,
+      });
+    });
+
+    it('should reject invalid sortBy', () => {
+      expectInvalidData(getAllProductsRequestSchema, {
+        title: null,
+        category: null,
+        price: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        sortBy: 'INVALID_SORT' as any,
+      });
+    });
+  });
+});
+
+describe('getProductRequestSchema - Filter by Arrays', () => {
+  describe('Valid Input', () => {
+    it('should accept valid filter data', () => {
+      expectValidData(getProductRequestSchema, {
+        ocasion: [Ocasions.VALENTINES_DAY],
+        categories: [Categories.GIFT_SET],
+        ProductContent: [ProductContent.COFFEE_TEA],
+      });
+    });
+
+    it('should accept empty arrays', () => {
+      expectValidData(getProductRequestSchema, {
+        ocasion: [],
+        categories: [],
+        ProductContent: [],
+      });
+    });
+
+    it('should accept multiple values in each array', () => {
+      expectValidData(getProductRequestSchema, {
+        ocasion: [Ocasions.VALENTINES_DAY, Ocasions.CHRISTMAS_NEW_YEAR],
+        categories: [Categories.GIFT_SET, Categories.FOR_HER],
+        ProductContent: [ProductContent.COFFEE_TEA, ProductContent.CHOCOLATE_BISCUITS_CANDY],
+      });
+    });
+  });
+
+  describe('Invalid Input', () => {
+    it('should reject missing ocasion', () => {
+      expectInvalidData(getProductRequestSchema, {
+        categories: [Categories.GIFT_SET],
+        ProductContent: [ProductContent.COFFEE_TEA],
+      });
+    });
+
+    it('should reject missing categories', () => {
+      expectInvalidData(getProductRequestSchema, {
+        ocasion: [Ocasions.VALENTINES_DAY],
+        ProductContent: [ProductContent.COFFEE_TEA],
+      });
+    });
+
+    it('should reject missing ProductContent', () => {
+      expectInvalidData(getProductRequestSchema, {
+        ocasion: [Ocasions.VALENTINES_DAY],
+        categories: [Categories.GIFT_SET],
+      });
+    });
+
+    it('should reject invalid ocasion enum', () => {
+      expectInvalidData(getProductRequestSchema, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ocasion: ['INVALID' as any],
+        categories: [Categories.GIFT_SET],
+        ProductContent: [ProductContent.COFFEE_TEA],
+      });
+    });
+  });
+});
+
+describe('getAdminProductsRequestSchema - Admin Listing', () => {
+  describe('Valid Input', () => {
+    it('should accept minimal data with defaults', () => {
+      expectValidData(getAdminProductsRequestSchema, {
+        title: null,
+      });
+    });
+
+    it('should apply default limit', () => {
+      const result = getAdminProductsRequestSchema.parse({ title: null });
+      expect(result.limit).toBe(10);
+    });
+
+    it('should apply default sortBy', () => {
+      const result = getAdminProductsRequestSchema.parse({ title: null });
+      expect(result.sortBy).toBe(SortBy.RECOMMENDED);
+    });
+
+    it('should accept title search with custom limit', () => {
+      expectValidData(getAdminProductsRequestSchema, {
+        title: 'Product',
+        limit: 50,
+      });
+    });
+
+    it('should accept pagination with cursor', () => {
+      expectValidData(getAdminProductsRequestSchema, {
+        title: null,
+        cursor: 25,
+        limit: 25,
+      });
+    });
+  });
+
+  describe('Invalid Input', () => {
+    it('should reject short title', () => {
+      expectInvalidData(getAdminProductsRequestSchema, {
+        title: 'a',
+      });
+    });
+
+    it('should reject limit above 100', () => {
+      expectInvalidData(getAdminProductsRequestSchema, {
+        title: null,
+        limit: 150,
+      });
+    });
+  });
+});
+
+describe('searchTagsRequestSchema - Tag Search', () => {
+  describe('Valid Input', () => {
+    it('should accept valid title with min 2 chars', () => {
+      expectValidData(searchTagsRequestSchema, {
+        title: 'ab',
+      });
+    });
+
+    it('should accept title search', () => {
+      expectValidData(searchTagsRequestSchema, {
+        title: 'chocolate',
+      });
+    });
+
+    it('should accept long title', () => {
+      expectValidData(searchTagsRequestSchema, {
+        title: 'a'.repeat(200),
+      });
+    });
+
+    it('should accept title with special characters', () => {
+      expectValidData(searchTagsRequestSchema, {
+        title: 'gift-set #1',
+      });
+    });
+  });
+
+  describe('Invalid Input', () => {
+    it('should reject title with 1 character', () => {
+      expectInvalidData(searchTagsRequestSchema, {
+        title: 'a',
+      });
+    });
+
+    it('should reject empty title', () => {
+      expectInvalidData(searchTagsRequestSchema, {
+        title: '',
+      });
+    });
+
+    it('should reject missing title', () => {
+      expectInvalidData(searchTagsRequestSchema, {});
+    });
+  });
+});
+
+describe('getRecProductsRequestSchema - Recommendations', () => {
+  describe('Valid Input', () => {
+    it('should accept valid category and productId', () => {
+      expectValidData(getRecProductsRequestSchema, {
+        category: Categories.GIFT_SET,
+        productId: 'product123',
+      });
+    });
+
+    it('should accept different categories', () => {
+      Object.values(Categories).forEach(category => {
+        expectValidData(getRecProductsRequestSchema, {
+          category,
+          productId: 'test-id',
+        });
+      });
+    });
+
+    it('should accept empty productId', () => {
+      expectValidData(getRecProductsRequestSchema, {
+        category: Categories.FOR_HER,
+        productId: '',
+      });
+    });
+  });
+
+  describe('Invalid Input', () => {
+    it('should reject missing category', () => {
+      expectInvalidData(getRecProductsRequestSchema, {
+        productId: 'product123',
+      });
+    });
+
+    it('should reject missing productId', () => {
+      expectInvalidData(getRecProductsRequestSchema, {
+        category: Categories.GIFT_SET,
+      });
+    });
+
+    it('should reject invalid category', () => {
+      expectInvalidData(getRecProductsRequestSchema, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        category: 'INVALID' as any,
+        productId: 'product123',
+      });
+    });
+
+    it('should reject non-string productId', () => {
+      expectInvalidData(getRecProductsRequestSchema, {
+        category: Categories.GIFT_SET,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        productId: 123 as any,
+      });
+    });
+  });
+});

--- a/src/lib/__tests__/validation/product/product-schemas.test.ts
+++ b/src/lib/__tests__/validation/product/product-schemas.test.ts
@@ -1,0 +1,539 @@
+import { describe, it } from 'vitest';
+import { addProductRequestSchema } from '@/lib/validation/product/addProductRequest';
+import { updateProductRequestSchema } from '@/lib/validation/product/updateProductRequest';
+import { deleteProductRequestSchema } from '@/lib/validation/product/deleteProductRequest';
+import { getProductRequestSchema } from '@/lib/validation/product/getProductRequest';
+import { Categories } from '@/lib/enums/Categories';
+import { Ocasions } from '@/lib/enums/Ocasions';
+import { ProductContent } from '@/lib/enums/ProductContent';
+import { StockState } from '@/lib/enums/StockState';
+import {
+  createMultilingualString,
+  createMongoId,
+  createInvalidMongoId,
+  expectValidData,
+  expectInvalidData,
+  testMongoIdField,
+} from '../shared/test-helpers';
+
+/**
+ * Product CRUD Schema Tests
+ *
+ * Tests for product CRUD validation schemas:
+ * - addProductRequestSchema: Create new product
+ * - updateProductRequestSchema: Update existing product
+ * - deleteProductRequestSchema: Delete product
+ * - getProductRequestSchema: Get single product
+ */
+
+// Helper to create valid product data
+const createValidProductData = () => ({
+  data: {
+    title: createMultilingualString('Product Title'),
+    description: createMultilingualString('Product Description'),
+    long_description: createMultilingualString('Long Description'),
+    image_description: createMultilingualString('Image Description'),
+    set_description: createMultilingualString('Set Description'),
+    price: 100,
+    nr_of_items: 5,
+    imagesChanged: true,
+    categories: [Categories.GIFT_SET],
+    ocasions: [Ocasions.WELCOME_KIT],
+    product_content: [ProductContent.COFFEE_TEA],
+    stock_availability: {
+      stock: 10,
+      state: StockState.IN_STOCK,
+    },
+    sale: {
+      active: false,
+      sale_price: 80,
+    },
+    imagesNumber: 3,
+    optional_info: {
+      weight: '500g',
+      dimensions: '10x10x10cm',
+      material: {
+        ro: 'Ceramică',
+        ru: 'Керамика',
+        en: 'Ceramic',
+      },
+      color: {
+        ro: 'Albastru',
+        ru: 'Синий',
+        en: 'Blue',
+      },
+    },
+  },
+});
+
+describe('addProductRequestSchema - Create Product', () => {
+  describe('Valid Input - Complete Product Data', () => {
+    it('should accept valid product data with all fields', () => {
+      expectValidData(addProductRequestSchema, createValidProductData());
+    });
+
+    it('should accept product data without optional set_description', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (data.data as any).set_description;
+      expectValidData(addProductRequestSchema, data);
+    });
+
+    it('should accept product data without optional sale', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (data.data as any).sale;
+      expectValidData(addProductRequestSchema, data);
+    });
+
+    it('should accept product data without optional imagesChanged', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (data.data as any).imagesChanged;
+      expectValidData(addProductRequestSchema, data);
+    });
+
+    it('should accept product with zero price', () => {
+      const data = createValidProductData();
+      data.data.price = 0;
+      expectValidData(addProductRequestSchema, data);
+    });
+
+    it('should accept product with multiple categories', () => {
+      const data = createValidProductData();
+      data.data.categories = [Categories.GIFT_SET, Categories.FOR_HER, Categories.ACCESSORIES];
+      expectValidData(addProductRequestSchema, data);
+    });
+
+    it('should accept product with multiple ocasions', () => {
+      const data = createValidProductData();
+      data.data.ocasions = [
+        Ocasions.WELCOME_KIT,
+        Ocasions.VALENTINES_DAY,
+        Ocasions.CHRISTMAS_NEW_YEAR,
+      ];
+      expectValidData(addProductRequestSchema, data);
+    });
+
+    it('should accept product with multiple product content types', () => {
+      const data = createValidProductData();
+      data.data.product_content = [
+        ProductContent.COFFEE_TEA,
+        ProductContent.CHOCOLATE_BISCUITS_CANDY,
+        ProductContent.NUTS_DRY_FRUITS_SPICES,
+      ];
+      expectValidData(addProductRequestSchema, data);
+    });
+  });
+
+  describe('Valid Input - All Categories', () => {
+    const allCategories = [
+      Categories.FOR_HER,
+      Categories.FOR_HIM,
+      Categories.FOR_KIDS,
+      Categories.ACCESSORIES,
+      Categories.FLOWERS_AND_BALLOONS,
+      Categories.GIFT_SET,
+    ];
+
+    allCategories.forEach(category => {
+      it(`should accept category: ${category}`, () => {
+        const data = createValidProductData();
+        data.data.categories = [category];
+        expectValidData(addProductRequestSchema, data);
+      });
+    });
+  });
+
+  describe('Valid Input - Price Variations', () => {
+    it('should accept decimal price', () => {
+      const data = createValidProductData();
+      data.data.price = 99.99;
+      expectValidData(addProductRequestSchema, data);
+    });
+
+    it('should accept very high price', () => {
+      const data = createValidProductData();
+      data.data.price = 999999.99;
+      expectValidData(addProductRequestSchema, data);
+    });
+  });
+
+  describe('Invalid Input - Negative Price', () => {
+    it('should reject negative price', () => {
+      const data = createValidProductData();
+      data.data.price = -10;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject negative sale price', () => {
+      const data = createValidProductData();
+      data.data.sale = {
+        active: true,
+        sale_price: -5,
+      };
+      expectInvalidData(addProductRequestSchema, data);
+    });
+  });
+
+  describe('Invalid Input - Missing Required Fields', () => {
+    it('should reject missing title', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (data.data as any).title;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject missing description', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (data.data as any).description;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject missing long_description', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (data.data as any).long_description;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject missing price', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (data.data as any).price;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject missing categories', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (data.data as any).categories;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject missing stock_availability', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (data.data as any).stock_availability;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+  });
+
+  describe('Invalid Input - Invalid Enum Values', () => {
+    it('should reject invalid category', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.data.categories = ['INVALID_CATEGORY' as any];
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject invalid ocasion', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.data.ocasions = ['INVALID_OCASION' as any];
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject invalid product content', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.data.product_content = ['INVALID_CONTENT' as any];
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject invalid stock state', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.data.stock_availability.state = 'INVALID_STATE' as any;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+  });
+
+  describe('Invalid Input - Wrong Types', () => {
+    it('should reject string for price', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.data.price = '100' as any;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject string for nr_of_items', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.data.nr_of_items = '5' as any;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject string for imagesNumber', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.data.imagesNumber = '3' as any;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject non-array for categories', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.data.categories = Categories.GIFT_SET as any;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+  });
+
+  describe('Invalid Input - Multilingual Field Validation', () => {
+    it('should reject title missing Romanian', () => {
+      const data = createValidProductData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.data.title = { ru: 'Test', en: 'Test' } as any;
+      expectInvalidData(addProductRequestSchema, data);
+    });
+
+    it('should reject description with empty string', () => {
+      const data = createValidProductData();
+      data.data.description = { ro: '', ru: '', en: '' };
+      expectInvalidData(addProductRequestSchema, data);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should accept empty arrays for categories', () => {
+      const data = createValidProductData();
+      data.data.categories = [];
+      expectValidData(addProductRequestSchema, data);
+    });
+
+    it('should accept zero stock', () => {
+      const data = createValidProductData();
+      data.data.stock_availability.stock = 0;
+      expectValidData(addProductRequestSchema, data);
+    });
+  });
+});
+
+describe('updateProductRequestSchema - Update Product', () => {
+  const createValidUpdateData = () => ({
+    ...createValidProductData(),
+    id: createMongoId(),
+  });
+
+  describe('Valid Input', () => {
+    it('should accept valid update data with MongoDB ID', () => {
+      expectValidData(updateProductRequestSchema, createValidUpdateData());
+    });
+
+    it('should accept update with all product fields changed', () => {
+      const data = createValidUpdateData();
+      data.data.price = 200;
+      data.data.title = createMultilingualString('Updated Title');
+      data.data.stock_availability.stock = 50;
+      expectValidData(updateProductRequestSchema, data);
+    });
+  });
+
+  describe('MongoDB ID Validation', () => {
+    testMongoIdField(updateProductRequestSchema, createValidUpdateData(), 'id');
+  });
+
+  describe('Invalid Input - Missing ID', () => {
+    it('should reject update data without ID', () => {
+      const data = createValidProductData();
+      expectInvalidData(updateProductRequestSchema, data);
+    });
+
+    it('should reject update data with invalid ID', () => {
+      const data = createValidUpdateData();
+      data.id = createInvalidMongoId();
+      expectInvalidData(updateProductRequestSchema, data);
+    });
+  });
+
+  describe('Invalid Input - All Product Validations Apply', () => {
+    it('should reject negative price in update', () => {
+      const data = createValidUpdateData();
+      data.data.price = -50;
+      expectInvalidData(updateProductRequestSchema, data);
+    });
+
+    it('should reject invalid category in update', () => {
+      const data = createValidUpdateData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data.data.categories = ['INVALID' as any];
+      expectInvalidData(updateProductRequestSchema, data);
+    });
+
+    it('should reject missing required field in update', () => {
+      const data = createValidUpdateData();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (data.data as any).title;
+      expectInvalidData(updateProductRequestSchema, data);
+    });
+  });
+});
+
+describe('deleteProductRequestSchema - Delete Product', () => {
+  describe('Valid Input', () => {
+    it('should accept valid MongoDB ID', () => {
+      expectValidData(deleteProductRequestSchema, {
+        id: createMongoId(),
+      });
+    });
+
+    it('should accept without ID (optional)', () => {
+      expectValidData(deleteProductRequestSchema, {});
+    });
+
+    it('should accept with undefined ID', () => {
+      expectValidData(deleteProductRequestSchema, {
+        id: undefined,
+      });
+    });
+  });
+
+  describe('Invalid Input - Invalid ID Format', () => {
+    it('should reject invalid MongoDB ID format', () => {
+      expectInvalidData(deleteProductRequestSchema, {
+        id: createInvalidMongoId(),
+      });
+    });
+
+    it('should reject ID shorter than 24 characters', () => {
+      expectInvalidData(deleteProductRequestSchema, {
+        id: '507f1f77bcf86cd7994390',
+      });
+    });
+
+    it('should reject ID longer than 24 characters', () => {
+      expectInvalidData(deleteProductRequestSchema, {
+        id: '507f1f77bcf86cd79943901111',
+      });
+    });
+
+    it('should reject non-string ID', () => {
+      expectInvalidData(deleteProductRequestSchema, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        id: 123456789012345678901234 as any,
+      });
+    });
+
+    it('should reject null ID', () => {
+      expectInvalidData(deleteProductRequestSchema, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        id: null as any,
+      });
+    });
+  });
+});
+
+describe('getProductRequestSchema - Get Single Product', () => {
+  describe('Valid Input', () => {
+    it('should accept valid MongoDB ID', () => {
+      expectValidData(getProductRequestSchema, {
+        id: createMongoId(),
+      });
+    });
+
+    it('should accept different valid MongoDB IDs', () => {
+      const validIds = [
+        '507f1f77bcf86cd799439011',
+        '5f9d88f9c9b7a1b7c8d8e8f8',
+        'a'.repeat(24),
+        '0'.repeat(24),
+      ];
+
+      validIds.forEach(id => {
+        expectValidData(getProductRequestSchema, { id });
+      });
+    });
+  });
+
+  describe('Invalid Input - Missing ID', () => {
+    it('should reject missing ID', () => {
+      expectInvalidData(getProductRequestSchema, {});
+    });
+
+    it('should reject undefined ID', () => {
+      expectInvalidData(getProductRequestSchema, {
+        id: undefined,
+      });
+    });
+
+    it('should reject null ID', () => {
+      expectInvalidData(getProductRequestSchema, {
+        id: null,
+      });
+    });
+  });
+
+  describe('Invalid Input - Invalid ID Format', () => {
+    it('should reject invalid MongoDB ID format', () => {
+      expectInvalidData(getProductRequestSchema, {
+        id: createInvalidMongoId(),
+      });
+    });
+
+    it('should reject empty string ID', () => {
+      expectInvalidData(getProductRequestSchema, {
+        id: '',
+      });
+    });
+
+    it('should reject ID with special characters', () => {
+      expectInvalidData(getProductRequestSchema, {
+        id: '507f1f77-bcf8-6cd7-9943',
+      });
+    });
+
+    it('should reject ID shorter than 24 characters', () => {
+      expectInvalidData(getProductRequestSchema, {
+        id: '507f1f77bcf86cd7994390',
+      });
+    });
+
+    it('should reject ID longer than 24 characters', () => {
+      expectInvalidData(getProductRequestSchema, {
+        id: '507f1f77bcf86cd79943901111',
+      });
+    });
+
+    it('should reject numeric ID', () => {
+      expectInvalidData(getProductRequestSchema, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        id: 123456 as any,
+      });
+    });
+
+    it('should reject boolean ID', () => {
+      expectInvalidData(getProductRequestSchema, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        id: true as any,
+      });
+    });
+
+    it('should reject object ID', () => {
+      expectInvalidData(getProductRequestSchema, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        id: { _id: createMongoId() } as any,
+      });
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should reject ID with whitespace', () => {
+      expectInvalidData(getProductRequestSchema, {
+        id: ' 507f1f77bcf86cd799439011',
+      });
+    });
+
+    it('should reject ID with leading zeros beyond 24 chars', () => {
+      expectInvalidData(getProductRequestSchema, {
+        id: '0507f1f77bcf86cd799439011',
+      });
+    });
+
+    it('should accept ID with all same characters', () => {
+      expectValidData(getProductRequestSchema, {
+        id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+      });
+    });
+  });
+});

--- a/src/lib/__tests__/validation/product/product-types.test.ts
+++ b/src/lib/__tests__/validation/product/product-types.test.ts
@@ -1,0 +1,637 @@
+import { describe, it } from 'vitest';
+import { productInfoSchema } from '@/lib/validation/product/types/productInfo';
+import { productSaleSchema } from '@/lib/validation/product/types/productSale';
+import { stockAvailabilitySchema } from '@/lib/validation/product/types/stockAvailability';
+import { optionalInfoSchema } from '@/lib/validation/product/types/optionalInfo';
+import { StockState } from '@/lib/enums/StockState';
+import {
+  createMultilingualString,
+  expectValidData,
+  expectInvalidData,
+  expectInvalidDataWithMessage,
+  XSS_PAYLOADS,
+  SQL_INJECTION_PAYLOADS,
+} from '../shared/test-helpers';
+
+/**
+ * Product Type Schemas Tests
+ *
+ * Tests for the core reusable type schemas used across product validation:
+ * - productInfoSchema: Multilingual strings (required)
+ * - productSaleSchema: Sale pricing
+ * - stockAvailabilitySchema: Stock state and quantity
+ * - optionalInfoSchema: Optional product details
+ */
+
+describe('productInfoSchema - Multilingual String Validation', () => {
+  const validData = createMultilingualString('Product');
+
+  describe('Valid Input', () => {
+    it('should accept valid multilingual data', () => {
+      expectValidData(productInfoSchema, validData);
+    });
+
+    it('should accept multilingual data with special characters', () => {
+      expectValidData(productInfoSchema, {
+        ro: 'Produse Țăști Șămănă',
+        ru: 'Продукты Тест',
+        en: 'Products Test',
+      });
+    });
+
+    it('should accept multilingual data with numbers and symbols', () => {
+      expectValidData(productInfoSchema, {
+        ro: 'Produse #1 - 50% reducere!',
+        ru: 'Продукт №1 - скидка 50%!',
+        en: 'Product #1 - 50% off!',
+      });
+    });
+
+    it('should accept multilingual data with long text', () => {
+      expectValidData(productInfoSchema, {
+        ro: 'a'.repeat(1000),
+        ru: 'б'.repeat(1000),
+        en: 'c'.repeat(1000),
+      });
+    });
+  });
+
+  describe('Invalid Input - Missing Languages', () => {
+    it('should reject missing Romanian', () => {
+      expectInvalidData(productInfoSchema, {
+        ru: 'Test RU',
+        en: 'Test EN',
+      });
+    });
+
+    it('should reject missing Russian', () => {
+      expectInvalidData(productInfoSchema, {
+        ro: 'Test RO',
+        en: 'Test EN',
+      });
+    });
+
+    it('should reject missing English', () => {
+      expectInvalidData(productInfoSchema, {
+        ro: 'Test RO',
+        ru: 'Test RU',
+      });
+    });
+
+    it('should reject missing all languages', () => {
+      expectInvalidData(productInfoSchema, {});
+    });
+  });
+
+  describe('Invalid Input - Empty Strings', () => {
+    it('should reject empty Romanian string', () => {
+      expectInvalidDataWithMessage(
+        productInfoSchema,
+        { ro: '', ru: 'Test RU', en: 'Test EN' },
+        'Completați câmpul'
+      );
+    });
+
+    it('should reject empty Russian string', () => {
+      expectInvalidDataWithMessage(
+        productInfoSchema,
+        { ro: 'Test RO', ru: '', en: 'Test EN' },
+        'Completați câmpul'
+      );
+    });
+
+    it('should reject empty English string', () => {
+      expectInvalidDataWithMessage(
+        productInfoSchema,
+        { ro: 'Test RO', ru: 'Test RU', en: '' },
+        'Completați câmpul'
+      );
+    });
+
+    it('should reject all empty strings', () => {
+      expectInvalidData(productInfoSchema, {
+        ro: '',
+        ru: '',
+        en: '',
+      });
+    });
+  });
+
+  describe('Invalid Input - Wrong Types', () => {
+    it('should reject null values', () => {
+      expectInvalidData(productInfoSchema, {
+        ro: null,
+        ru: null,
+        en: null,
+      });
+    });
+
+    it('should reject undefined values', () => {
+      expectInvalidData(productInfoSchema, {
+        ro: undefined,
+        ru: undefined,
+        en: undefined,
+      });
+    });
+
+    it('should reject number values', () => {
+      expectInvalidData(productInfoSchema, {
+        ro: 123,
+        ru: 456,
+        en: 789,
+      });
+    });
+
+    it('should reject boolean values', () => {
+      expectInvalidData(productInfoSchema, {
+        ro: true,
+        ru: false,
+        en: true,
+      });
+    });
+
+    it('should reject object values', () => {
+      expectInvalidData(productInfoSchema, {
+        ro: { nested: 'object' },
+        ru: { nested: 'object' },
+        en: { nested: 'object' },
+      });
+    });
+  });
+
+  describe('Security - XSS and SQL Injection', () => {
+    it('should accept XSS payloads (sanitization should happen at application layer)', () => {
+      XSS_PAYLOADS.forEach(payload => {
+        expectValidData(productInfoSchema, {
+          ro: payload,
+          ru: payload,
+          en: payload,
+        });
+      });
+    });
+
+    it('should accept SQL injection payloads (sanitization should happen at application layer)', () => {
+      SQL_INJECTION_PAYLOADS.forEach(payload => {
+        expectValidData(productInfoSchema, {
+          ro: payload,
+          ru: payload,
+          en: payload,
+        });
+      });
+    });
+  });
+});
+
+describe('productSaleSchema - Sale Price Validation', () => {
+  const validData = {
+    active: true,
+    sale_price: 100,
+  };
+
+  describe('Valid Input', () => {
+    it('should accept valid sale data with active true', () => {
+      expectValidData(productSaleSchema, validData);
+    });
+
+    it('should accept sale data with active false', () => {
+      expectValidData(productSaleSchema, {
+        active: false,
+        sale_price: 50,
+      });
+    });
+
+    it('should accept zero price', () => {
+      expectValidData(productSaleSchema, {
+        active: true,
+        sale_price: 0,
+      });
+    });
+
+    it('should accept very high price', () => {
+      expectValidData(productSaleSchema, {
+        active: true,
+        sale_price: 999999.99,
+      });
+    });
+
+    it('should accept decimal prices', () => {
+      expectValidData(productSaleSchema, {
+        active: true,
+        sale_price: 19.99,
+      });
+    });
+  });
+
+  describe('Invalid Input - Negative Price', () => {
+    it('should reject negative price', () => {
+      expectInvalidDataWithMessage(
+        productSaleSchema,
+        { active: true, sale_price: -10 },
+        'Price cannot be below 0'
+      );
+    });
+
+    it('should reject very small negative price', () => {
+      expectInvalidDataWithMessage(
+        productSaleSchema,
+        { active: true, sale_price: -0.01 },
+        'Price cannot be below 0'
+      );
+    });
+  });
+
+  describe('Invalid Input - Missing Fields', () => {
+    it('should reject missing active field', () => {
+      expectInvalidData(productSaleSchema, {
+        sale_price: 100,
+      });
+    });
+
+    it('should reject missing sale_price field', () => {
+      expectInvalidData(productSaleSchema, {
+        active: true,
+      });
+    });
+
+    it('should reject missing both fields', () => {
+      expectInvalidData(productSaleSchema, {});
+    });
+  });
+
+  describe('Invalid Input - Wrong Types', () => {
+    it('should reject string for active field', () => {
+      expectInvalidData(productSaleSchema, {
+        active: 'true',
+        sale_price: 100,
+      });
+    });
+
+    it('should reject number for active field', () => {
+      expectInvalidData(productSaleSchema, {
+        active: 1,
+        sale_price: 100,
+      });
+    });
+
+    it('should reject string for sale_price', () => {
+      expectInvalidData(productSaleSchema, {
+        active: true,
+        sale_price: '100',
+      });
+    });
+
+    it('should reject null for sale_price', () => {
+      expectInvalidData(productSaleSchema, {
+        active: true,
+        sale_price: null,
+      });
+    });
+  });
+});
+
+describe('stockAvailabilitySchema - Stock State Validation', () => {
+  describe('Valid Input - All Stock States', () => {
+    it('should accept IN_STOCK state', () => {
+      expectValidData(stockAvailabilitySchema, {
+        stock: 10,
+        state: StockState.IN_STOCK,
+      });
+    });
+
+    it('should accept ON_COMMAND state', () => {
+      expectValidData(stockAvailabilitySchema, {
+        stock: 0,
+        state: StockState.ON_COMMAND,
+      });
+    });
+
+    it('should accept NOT_IN_STOCK state', () => {
+      expectValidData(stockAvailabilitySchema, {
+        stock: 0,
+        state: StockState.NOT_IN_STOCK,
+      });
+    });
+  });
+
+  describe('Valid Input - Stock Quantities', () => {
+    it('should accept zero stock', () => {
+      expectValidData(stockAvailabilitySchema, {
+        stock: 0,
+        state: StockState.NOT_IN_STOCK,
+      });
+    });
+
+    it('should accept positive stock', () => {
+      expectValidData(stockAvailabilitySchema, {
+        stock: 100,
+        state: StockState.IN_STOCK,
+      });
+    });
+
+    it('should accept very large stock', () => {
+      expectValidData(stockAvailabilitySchema, {
+        stock: 999999,
+        state: StockState.IN_STOCK,
+      });
+    });
+  });
+
+  describe('Invalid Input - Invalid Stock State', () => {
+    it('should reject invalid state string', () => {
+      expectInvalidData(stockAvailabilitySchema, {
+        stock: 10,
+        state: 'INVALID_STATE',
+      });
+    });
+
+    it('should reject numeric state', () => {
+      expectInvalidData(stockAvailabilitySchema, {
+        stock: 10,
+        state: 1,
+      });
+    });
+
+    it('should reject null state', () => {
+      expectInvalidData(stockAvailabilitySchema, {
+        stock: 10,
+        state: null,
+      });
+    });
+  });
+
+  describe('Invalid Input - Invalid Stock Quantity', () => {
+    it('should reject string stock', () => {
+      expectInvalidData(stockAvailabilitySchema, {
+        stock: '10',
+        state: StockState.IN_STOCK,
+      });
+    });
+
+    it('should reject null stock', () => {
+      expectInvalidData(stockAvailabilitySchema, {
+        stock: null,
+        state: StockState.IN_STOCK,
+      });
+    });
+
+    it('should reject undefined stock', () => {
+      expectInvalidData(stockAvailabilitySchema, {
+        stock: undefined,
+        state: StockState.IN_STOCK,
+      });
+    });
+  });
+
+  describe('Edge Cases - Accepted by Schema', () => {
+    it('should accept negative stock (no min constraint in schema)', () => {
+      expectValidData(stockAvailabilitySchema, {
+        stock: -10,
+        state: StockState.NOT_IN_STOCK,
+      });
+    });
+
+    it('should accept decimal stock (no integer constraint in schema)', () => {
+      expectValidData(stockAvailabilitySchema, {
+        stock: 10.5,
+        state: StockState.IN_STOCK,
+      });
+    });
+  });
+
+  describe('Invalid Input - Missing Fields', () => {
+    it('should reject missing stock field', () => {
+      expectInvalidData(stockAvailabilitySchema, {
+        state: StockState.IN_STOCK,
+      });
+    });
+
+    it('should reject missing state field', () => {
+      expectInvalidData(stockAvailabilitySchema, {
+        stock: 10,
+      });
+    });
+
+    it('should reject missing both fields', () => {
+      expectInvalidData(stockAvailabilitySchema, {});
+    });
+  });
+});
+
+describe('optionalInfoSchema - Optional Product Details', () => {
+  const createValidOptionalInfo = () => ({
+    weight: '500g',
+    dimensions: '10x10x10cm',
+    material: {
+      ro: 'Ceramică',
+      ru: 'Керамика',
+      en: 'Ceramic',
+    },
+    color: {
+      ro: 'Albastru',
+      ru: 'Синий',
+      en: 'Blue',
+    },
+  });
+
+  describe('Valid Input - All Fields', () => {
+    it('should accept all optional fields filled', () => {
+      expectValidData(optionalInfoSchema, createValidOptionalInfo());
+    });
+
+    it('should accept all fields empty/undefined', () => {
+      expectValidData(optionalInfoSchema, {
+        weight: undefined,
+        dimensions: undefined,
+        material: {
+          ro: undefined,
+          ru: undefined,
+          en: undefined,
+        },
+        color: {
+          ro: undefined,
+          ru: undefined,
+          en: undefined,
+        },
+      });
+    });
+
+    it('should accept partially filled multilingual fields', () => {
+      expectValidData(optionalInfoSchema, {
+        weight: '1kg',
+        dimensions: '20x20x20cm',
+        material: {
+          ro: 'Sticlă',
+          ru: undefined,
+          en: 'Glass',
+        },
+        color: {
+          ro: undefined,
+          ru: 'Красный',
+          en: undefined,
+        },
+      });
+    });
+  });
+
+  describe('Valid Input - Partial Fields', () => {
+    it('should accept only weight', () => {
+      expectValidData(optionalInfoSchema, {
+        weight: '250g',
+        dimensions: undefined,
+        material: { ro: undefined, ru: undefined, en: undefined },
+        color: { ro: undefined, ru: undefined, en: undefined },
+      });
+    });
+
+    it('should accept only dimensions', () => {
+      expectValidData(optionalInfoSchema, {
+        weight: undefined,
+        dimensions: '5x5x5cm',
+        material: { ro: undefined, ru: undefined, en: undefined },
+        color: { ro: undefined, ru: undefined, en: undefined },
+      });
+    });
+
+    it('should accept only material', () => {
+      expectValidData(optionalInfoSchema, {
+        weight: undefined,
+        dimensions: undefined,
+        material: {
+          ro: 'Plastic',
+          ru: 'Пластик',
+          en: 'Plastic',
+        },
+        color: { ro: undefined, ru: undefined, en: undefined },
+      });
+    });
+
+    it('should accept only color', () => {
+      expectValidData(optionalInfoSchema, {
+        weight: undefined,
+        dimensions: undefined,
+        material: { ro: undefined, ru: undefined, en: undefined },
+        color: {
+          ro: 'Verde',
+          ru: 'Зелёный',
+          en: 'Green',
+        },
+      });
+    });
+  });
+
+  describe('Valid Input - Empty Strings', () => {
+    it('should accept empty strings for weight and dimensions', () => {
+      expectValidData(optionalInfoSchema, {
+        weight: '',
+        dimensions: '',
+        material: { ro: undefined, ru: undefined, en: undefined },
+        color: { ro: undefined, ru: undefined, en: undefined },
+      });
+    });
+
+    it('should accept empty strings in multilingual fields', () => {
+      expectValidData(optionalInfoSchema, {
+        weight: undefined,
+        dimensions: undefined,
+        material: {
+          ro: '',
+          ru: '',
+          en: '',
+        },
+        color: {
+          ro: '',
+          ru: '',
+          en: '',
+        },
+      });
+    });
+  });
+
+  describe('Invalid Input - Wrong Types', () => {
+    it('should reject number for weight', () => {
+      expectInvalidData(optionalInfoSchema, {
+        weight: 500,
+        dimensions: undefined,
+        material: { ro: undefined, ru: undefined, en: undefined },
+        color: { ro: undefined, ru: undefined, en: undefined },
+      });
+    });
+
+    it('should reject number for dimensions', () => {
+      expectInvalidData(optionalInfoSchema, {
+        weight: undefined,
+        dimensions: 100,
+        material: { ro: undefined, ru: undefined, en: undefined },
+        color: { ro: undefined, ru: undefined, en: undefined },
+      });
+    });
+
+    it('should reject non-object for material', () => {
+      expectInvalidData(optionalInfoSchema, {
+        weight: undefined,
+        dimensions: undefined,
+        material: 'Ceramic',
+        color: { ro: undefined, ru: undefined, en: undefined },
+      });
+    });
+
+    it('should reject non-object for color', () => {
+      expectInvalidData(optionalInfoSchema, {
+        weight: undefined,
+        dimensions: undefined,
+        material: { ro: undefined, ru: undefined, en: undefined },
+        color: 'Blue',
+      });
+    });
+  });
+
+  describe('Invalid Input - Missing Required Structure', () => {
+    it('should reject missing material field', () => {
+      expectInvalidData(optionalInfoSchema, {
+        weight: undefined,
+        dimensions: undefined,
+        color: { ro: undefined, ru: undefined, en: undefined },
+      });
+    });
+
+    it('should reject missing color field', () => {
+      expectInvalidData(optionalInfoSchema, {
+        weight: undefined,
+        dimensions: undefined,
+        material: { ro: undefined, ru: undefined, en: undefined },
+      });
+    });
+
+    it('should reject completely empty object', () => {
+      expectInvalidData(optionalInfoSchema, {});
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should accept very long weight string', () => {
+      expectValidData(optionalInfoSchema, {
+        weight: 'a'.repeat(500),
+        dimensions: undefined,
+        material: { ro: undefined, ru: undefined, en: undefined },
+        color: { ro: undefined, ru: undefined, en: undefined },
+      });
+    });
+
+    it('should accept special characters in all fields', () => {
+      expectValidData(optionalInfoSchema, {
+        weight: '500g (±10g)',
+        dimensions: '10×10×10 cm²',
+        material: {
+          ro: 'Ceramică @ 100%',
+          ru: 'Керамика # №1',
+          en: 'Ceramic & Glass',
+        },
+        color: {
+          ro: 'Albastru-verzui',
+          ru: 'Сине-зелёный',
+          en: 'Blue-greenish',
+        },
+      });
+    });
+  });
+});

--- a/src/lib/__tests__/validation/shared/test-helpers.ts
+++ b/src/lib/__tests__/validation/shared/test-helpers.ts
@@ -1,0 +1,378 @@
+import { it, expect } from 'vitest';
+import type { ZodSchema, ZodError } from 'zod';
+
+/**
+ * Shared Test Helpers for Validation Schema Testing
+ *
+ * This file provides utility functions for testing Zod validation schemas
+ * across the entire validation test suite.
+ */
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+export interface MultilingualString {
+  ro: string;
+  ru: string;
+  en: string;
+}
+
+// ============================================================================
+// Data Generators
+// ============================================================================
+
+/**
+ * Generate a valid multilingual string object
+ */
+export function createMultilingualString(base: string = 'Test'): MultilingualString {
+  return {
+    ro: `${base} RO`,
+    ru: `${base} RU`,
+    en: `${base} EN`,
+  };
+}
+
+/**
+ * Generate a valid MongoDB ObjectId (24 hex characters)
+ */
+export function createMongoId(): string {
+  return '507f1f77bcf86cd799439011';
+}
+
+/**
+ * Generate an invalid MongoDB ObjectId
+ */
+export function createInvalidMongoId(): string {
+  return 'invalid-id-123';
+}
+
+/**
+ * Generate a valid email address
+ */
+export function createValidEmail(): string {
+  return 'test@example.com';
+}
+
+/**
+ * Generate an invalid email address
+ */
+export function createInvalidEmail(): string {
+  return 'invalid-email';
+}
+
+// ============================================================================
+// Security Test Payloads
+// ============================================================================
+
+/**
+ * Common XSS attack payloads for testing
+ */
+export const XSS_PAYLOADS = [
+  '<script>alert("xss")</script>',
+  '<img src=x onerror=alert("xss")>',
+  'javascript:alert("xss")',
+  '<iframe src="javascript:alert(\'xss\')">',
+  '<svg onload=alert("xss")>',
+];
+
+/**
+ * Common SQL injection payloads for testing
+ */
+export const SQL_INJECTION_PAYLOADS = [
+  "'; DROP TABLE products;--",
+  "' OR '1'='1",
+  "admin'--",
+  "1' UNION SELECT NULL--",
+];
+
+/**
+ * Create a multilingual object with XSS payload
+ */
+export function createXSSMultilingual(): MultilingualString {
+  return {
+    ro: '<script>alert("xss")</script>',
+    ru: '<img src=x onerror=alert("xss")>',
+    en: 'javascript:alert("xss")',
+  };
+}
+
+// ============================================================================
+// Test Assertion Helpers
+// ============================================================================
+
+/**
+ * Test that a schema accepts valid data
+ */
+export function expectValidData<T>(schema: ZodSchema<T>, data: unknown): void {
+  const result = schema.safeParse(data);
+  expect(result.success).toBe(true);
+  if (result.success) {
+    expect(result.data).toBeDefined();
+  }
+}
+
+/**
+ * Test that a schema rejects invalid data
+ */
+export function expectInvalidData(schema: ZodSchema, data: unknown): void {
+  const result = schema.safeParse(data);
+  expect(result.success).toBe(false);
+}
+
+/**
+ * Test that a schema rejects invalid data with a specific error message
+ */
+export function expectInvalidDataWithMessage(
+  schema: ZodSchema,
+  data: unknown,
+  expectedMessage: string | RegExp
+): void {
+  const result = schema.safeParse(data);
+  expect(result.success).toBe(false);
+
+  if (!result.success) {
+    const errorMessages = result.error.errors.map(err => err.message).join(', ');
+    if (typeof expectedMessage === 'string') {
+      expect(errorMessages).toContain(expectedMessage);
+    } else {
+      expect(errorMessages).toMatch(expectedMessage);
+    }
+  }
+}
+
+/**
+ * Test that a schema rejects invalid data with an error at a specific path
+ */
+export function expectInvalidDataAtPath(
+  schema: ZodSchema,
+  data: unknown,
+  expectedPath: (string | number)[]
+): void {
+  const result = schema.safeParse(data);
+  expect(result.success).toBe(false);
+
+  if (!result.success) {
+    const hasPathError = result.error.errors.some(err => {
+      return JSON.stringify(err.path) === JSON.stringify(expectedPath);
+    });
+    expect(hasPathError).toBe(true);
+  }
+}
+
+/**
+ * Get all error messages from a validation error
+ */
+export function getErrorMessages(error: ZodError): string[] {
+  return error.errors.map(err => err.message);
+}
+
+/**
+ * Get all error paths from a validation error
+ */
+export function getErrorPaths(error: ZodError): (string | number)[][] {
+  return error.errors.map(err => err.path);
+}
+
+// ============================================================================
+// Common Test Patterns
+// ============================================================================
+
+/**
+ * Test that all fields in an object are required
+ */
+export function testRequiredFields(
+  schema: ZodSchema,
+  validData: Record<string, unknown>,
+  requiredFields: string[]
+): void {
+  requiredFields.forEach(field => {
+    it(`should require ${field} field`, () => {
+      const invalidData = { ...validData };
+      delete invalidData[field];
+      expectInvalidData(schema, invalidData);
+    });
+  });
+}
+
+/**
+ * Test string length constraints
+ */
+export function testStringLength(
+  schema: ZodSchema,
+  validData: Record<string, unknown>,
+  field: string,
+  min?: number,
+  max?: number
+): void {
+  if (min !== undefined) {
+    it(`should reject ${field} shorter than ${min} characters`, () => {
+      const invalidData = { ...validData, [field]: 'a'.repeat(min - 1) };
+      expectInvalidData(schema, invalidData);
+    });
+  }
+
+  if (max !== undefined) {
+    it(`should reject ${field} longer than ${max} characters`, () => {
+      const invalidData = { ...validData, [field]: 'a'.repeat(max + 1) };
+      expectInvalidData(schema, invalidData);
+    });
+  }
+}
+
+/**
+ * Test that a field accepts valid enum values
+ */
+export function testEnumField<T extends Record<string, string>>(
+  schema: ZodSchema,
+  validData: Record<string, unknown>,
+  field: string,
+  enumObject: T,
+  validValues: T[keyof T][]
+): void {
+  validValues.forEach(value => {
+    it(`should accept ${field} = ${value}`, () => {
+      const data = { ...validData, [field]: value };
+      expectValidData(schema, data);
+    });
+  });
+
+  it(`should reject invalid ${field} value`, () => {
+    const invalidData = { ...validData, [field]: 'INVALID_ENUM_VALUE' };
+    expectInvalidData(schema, invalidData);
+  });
+}
+
+/**
+ * Test multilingual field validation
+ */
+export function testMultilingualField(
+  schema: ZodSchema,
+  validData: Record<string, unknown>,
+  field: string
+): void {
+  it(`should require all languages for ${field}`, () => {
+    expectValidData(schema, {
+      ...validData,
+      [field]: createMultilingualString('Valid'),
+    });
+  });
+
+  it(`should reject ${field} missing Romanian`, () => {
+    expectInvalidData(schema, {
+      ...validData,
+      [field]: { ru: 'Test RU', en: 'Test EN' },
+    });
+  });
+
+  it(`should reject ${field} missing Russian`, () => {
+    expectInvalidData(schema, {
+      ...validData,
+      [field]: { ro: 'Test RO', en: 'Test EN' },
+    });
+  });
+
+  it(`should reject ${field} missing English`, () => {
+    expectInvalidData(schema, {
+      ...validData,
+      [field]: { ro: 'Test RO', ru: 'Test RU' },
+    });
+  });
+
+  it(`should reject ${field} with empty strings`, () => {
+    expectInvalidData(schema, {
+      ...validData,
+      [field]: { ro: '', ru: '', en: '' },
+    });
+  });
+}
+
+/**
+ * Test MongoDB ObjectId validation
+ */
+export function testMongoIdField(
+  schema: ZodSchema,
+  validData: Record<string, unknown>,
+  field: string
+): void {
+  it(`should accept valid MongoDB ObjectId for ${field}`, () => {
+    expectValidData(schema, {
+      ...validData,
+      [field]: createMongoId(),
+    });
+  });
+
+  it(`should reject invalid MongoDB ObjectId for ${field}`, () => {
+    expectInvalidData(schema, {
+      ...validData,
+      [field]: createInvalidMongoId(),
+    });
+  });
+
+  it(`should reject ${field} shorter than 24 characters`, () => {
+    expectInvalidData(schema, {
+      ...validData,
+      [field]: '507f1f77bcf86cd7994390',
+    });
+  });
+
+  it(`should reject ${field} longer than 24 characters`, () => {
+    expectInvalidData(schema, {
+      ...validData,
+      [field]: '507f1f77bcf86cd79943901111',
+    });
+  });
+}
+
+/**
+ * Test number range validation
+ */
+export function testNumberRange(
+  schema: ZodSchema,
+  validData: Record<string, unknown>,
+  field: string,
+  min?: number,
+  max?: number
+): void {
+  if (min !== undefined) {
+    it(`should accept ${field} at minimum value ${min}`, () => {
+      expectValidData(schema, { ...validData, [field]: min });
+    });
+
+    it(`should reject ${field} below minimum ${min}`, () => {
+      expectInvalidData(schema, { ...validData, [field]: min - 1 });
+    });
+  }
+
+  if (max !== undefined) {
+    it(`should accept ${field} at maximum value ${max}`, () => {
+      expectValidData(schema, { ...validData, [field]: max });
+    });
+
+    it(`should reject ${field} above maximum ${max}`, () => {
+      expectInvalidData(schema, { ...validData, [field]: max + 1 });
+    });
+  }
+}
+
+/**
+ * Test that a schema handles special characters properly
+ */
+export function testSpecialCharacters(
+  schema: ZodSchema,
+  validData: Record<string, unknown>,
+  field: string
+): void {
+  const specialCharTestCases = [
+    { name: 'Romanian diacritics', value: 'Țăști Șămănă' },
+    { name: 'Cyrillic characters', value: 'Продукт Тест' },
+    { name: 'Mixed characters', value: 'Test Țest Тест' },
+    { name: 'Unicode symbols', value: 'Test ✓ ™ ©' },
+  ];
+
+  specialCharTestCases.forEach(({ name, value }) => {
+    it(`should handle ${name} in ${field}`, () => {
+      expectValidData(schema, { ...validData, [field]: value });
+    });
+  });
+}


### PR DESCRIPTION
## TLDR

Add comprehensive validation tests for all product-related Zod schemas with 213 tests covering valid/invalid inputs, enums, multilingual fields, security, and edge cases.

## Related Issue

Part of #13 (Part 1 - Product schemas complete)

## Changes Made

### Test Infrastructure
- **Shared test helpers** (`test-helpers.ts`)
  - Data generators (multilingual strings, MongoDB IDs, emails)
  - Security test payloads (XSS, SQL injection)
  - Assertion helpers (expectValidData, expectInvalidData, etc.)
  - Common test patterns (required fields, string length, enums, etc.)

### Product Type Schemas (68 tests)
- `productInfoSchema`: Multilingual string validation
- `productSaleSchema`: Sale pricing with negative price rejection
- `stockAvailabilitySchema`: Stock state enum + quantity
- `optionalInfoSchema`: Optional multilingual product details

### Product CRUD Schemas (71 tests)
- `addProductRequestSchema`: Complete product creation with all fields
- `updateProductRequestSchema`: Extends add with MongoDB ID validation
- `deleteProductRequestSchema`: Optional ID for deletion
- `getProductRequestSchema`: Required ID for fetching

### Product Filter Schemas (74 tests)
- `getAllProductsRequestSchema`: Complex filtering (title, category, price range, ocasions, content, sorting, pagination)
- `getProductsByFilter`: Array-based filtering
- `getAdminProductsRequestSchema`: Admin product listing
- `searchTagsRequestSchema`: Tag search with min length
- `getRecProductsRequestSchema`: Recommendations by category

## Test Coverage

**What's Tested:**
✅ All 11 product validation schema files
✅ Valid input acceptance (min/max values, all enum options)
✅ Invalid input rejection (missing fields, wrong types, bad enums)
✅ MongoDB ID format (24-character hex validation)
✅ Multilingual fields (ro/ru/en required, empty string rejection)
✅ Security payloads (XSS and SQL injection - validated at schema level)
✅ Type validation (string/number/boolean/array enforcement)
✅ Edge cases (empty arrays, null vs undefined, boundary values)

## Testing Strategy

Each test file follows a consistent pattern:
1. **Valid Input Tests**: All valid variations and combinations
2. **Invalid Input Tests**: Missing fields, wrong types, bad values
3. **Enum Validation**: All enum values tested individually
4. **Security Tests**: XSS/SQL injection payloads
5. **Edge Cases**: Boundary conditions, special characters

## Implementation Details

**Test Organization:**
```
src/lib/__tests__/validation/
├── shared/
│   └── test-helpers.ts          # Reusable test utilities
└── product/
    ├── product-types.test.ts    # Type schemas (68 tests)
    ├── product-schemas.test.ts  # CRUD schemas (71 tests)
    └── product-filters.test.ts  # Filter schemas (74 tests)
```

**Key Patterns:**
- Used ESLint disable comments for intentional `any` in invalid tests
- TypeScript strict mode compliance (type assertions for delete operations)
- Followed existing test patterns from `utils.test.ts`
- Used Vitest as the test runner (already configured)

## Commits

- 62b6508: test(validation): add shared test helpers and utilities
- 9c5fd3f: test(validation): add comprehensive tests for product type schemas
- a9b61c2: test(validation): add comprehensive tests for product CRUD schemas
- 6af64d9: test(validation): add product filter schema tests (74 tests)

## Testing

✅ All tests pass: `npm test`
```
Test Files  16 passed (16)
Tests  598 passed (598)
```

✅ TypeScript compilation: `npm run typecheck` ✓
✅ Build succeeds: `npm run build` ✓
✅ Husky pre-commit hooks: All checks pass ✓

## Part 2 - Remaining Work

The following validation schemas will be covered in a follow-up PR:

**Order Schemas** (~130 tests)
- Order type schemas (UserData, Addresses, DeliveryDetails)
- Order CRUD schemas with 6+ cross-field refinements
- Complex conditional validation testing

**Other Schemas** (~112 tests)
- Blog schemas (CRUD + multilingual sections)
- Image upload/delete schemas
- Contact form schema (regex + refinements)
- Home banner/occasion schemas
- Miscellaneous (login, search, recommendations)
- Documentation in `/docs/testing/validation-tests.md`

## Checklist

- [x] Code follows project conventions (CLAUDE.md)
- [x] All commits pass typecheck and build
- [x] Test helpers are reusable and well-documented
- [x] All product validation schemas have comprehensive tests
- [x] Security considerations tested (XSS/SQL injection)
- [x] Multilingual validation (ro/ru/en) thoroughly tested
- [x] Ready for review

---

**Test Stats:**
- 📊 213 new tests
- 📝 ~2,131 lines of test code
- 🎯 47% of total validation test coverage (Part 1)
- ⚡ All tests passing